### PR TITLE
Update dependency on Apache commons-lang to 3

### DIFF
--- a/ehcachetag/pom.xml
+++ b/ehcachetag/pom.xml
@@ -14,9 +14,9 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.ehcache</groupId>

--- a/ehcachetag/src/main/java/nl/siegmann/ehcachetag/CacheTag.java
+++ b/ehcachetag/src/main/java/nl/siegmann/ehcachetag/CacheTag.java
@@ -15,7 +15,7 @@ import nl.siegmann.ehcachetag.cachetagmodifier.CacheTagModifier;
 import nl.siegmann.ehcachetag.cachetagmodifier.CacheTagModifierFactory;
 import nl.siegmann.ehcachetag.util.StringUtil;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ehcachetag/src/main/java/nl/siegmann/ehcachetag/EHCacheTagServletContextListener.java
+++ b/ehcachetag/src/main/java/nl/siegmann/ehcachetag/EHCacheTagServletContextListener.java
@@ -7,7 +7,7 @@ import javax.servlet.ServletContextListener;
 import nl.siegmann.ehcachetag.cachetagmodifier.CacheTagModifierFactory;
 import nl.siegmann.ehcachetag.cachetagmodifier.DefaultCacheTagModifierFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ehcachetag/src/main/java/nl/siegmann/ehcachetag/cachetagmodifier/CompositeCacheKey.java
+++ b/ehcachetag/src/main/java/nl/siegmann/ehcachetag/cachetagmodifier/CompositeCacheKey.java
@@ -1,7 +1,7 @@
 package nl.siegmann.ehcachetag.cachetagmodifier;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * An object that can be used as a cache key where all components are used for hashCode and equals calculation.

--- a/ehcachetag/src/main/java/nl/siegmann/ehcachetag/cachetagmodifier/DefaultCacheTagModifierFactory.java
+++ b/ehcachetag/src/main/java/nl/siegmann/ehcachetag/cachetagmodifier/DefaultCacheTagModifierFactory.java
@@ -9,7 +9,7 @@ import javax.servlet.ServletContext;
 import nl.siegmann.ehcachetag.EHCacheTagConstants;
 import nl.siegmann.ehcachetag.util.BeanFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ehcachetag/src/main/java/nl/siegmann/ehcachetag/util/BeanFactory.java
+++ b/ehcachetag/src/main/java/nl/siegmann/ehcachetag/util/BeanFactory.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ehcachetag/src/main/java/nl/siegmann/ehcachetag/util/StringUtil.java
+++ b/ehcachetag/src/main/java/nl/siegmann/ehcachetag/util/StringUtil.java
@@ -2,7 +2,7 @@ package nl.siegmann.ehcachetag.util;
 
 import java.util.Collection;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class StringUtil {
 


### PR DESCRIPTION
Apache commons lang has a new version out for a long, long time, however due to downwards incompatibility it has renamed artifacts and package names. This changeset updates to the newest version.
